### PR TITLE
bugfix horizonal orientation in bb_annoHeatmapLegend

### DIFF
--- a/R/bb_annoHeatmapLegend.R
+++ b/R/bb_annoHeatmapLegend.R
@@ -221,7 +221,7 @@ bb_annoHeatmapLegend <- function(plot, x, y, width, height, params = NULL, borde
 
     new_width <- 1 - (hW + lW + dW)
 
-    color_scale <- rasterGrob(matrix(data = color_scale, nrow = 1, ncol = length(bb_heatmapLegend$color_palette)), width = unit(new_width, "npc"), height = page_coords$height,
+    color_scale <- rasterGrob(matrix(data = color_scale, nrow = 1, ncol = length(color_scale)), width = unit(new_width, "npc"), height = page_coords$height,
                 x = unit(lW + (0.5 * dW), "npc"), just = "left")
 
     if (bb_heatmapLegendInternal$border == T){


### PR DESCRIPTION
There was a bug in bb_annoHeatmapLegend where the horizontal legend didn't plot anything. Exchanged for the correct variable.